### PR TITLE
Add time checks to handle self-marking

### DIFF
--- a/classes/form/studentattendance.php
+++ b/classes/form/studentattendance.php
@@ -48,7 +48,7 @@ class studentattendance extends \moodleform {
         // Check if user has access to all statuses.
         $disabledduetotime = false;
         foreach ($statuses as $status) {
-            if ($status->studentavailability === '0') {
+            if ($status->studentavailability === '0' && time() > $attforsession->sessdate) {
                 unset($statuses[$status->id]);
             }
             if (!empty($status->studentavailability) &&
@@ -57,6 +57,9 @@ class studentattendance extends \moodleform {
                 $disabledduetotime = true;
             }
             if ($status->availablebeforesession == 0  && time() < $attforsession->sessdate) {
+                unset($statuses[$status->id]);
+            }
+            if ($status->availablebeforesession == 1 && time() < $attforsession->sessdate - $attforsession->studentsearlyopentime) {
                 unset($statuses[$status->id]);
             }
         }

--- a/locallib.php
+++ b/locallib.php
@@ -606,7 +606,7 @@ function attendance_can_student_mark($sess, $log = true) {
 
     if (!empty($attconfig->studentscanmark) && !empty($sess->studentscanmark)) {
         if (empty($attconfig->studentscanmarksessiontime) ||
-            (is_status_availablebeforesession($sess->id) > 0) && time() < $sess->sessdate) {
+            (is_status_availablebeforesession($sess->id) > 0) && time() > $sess->sessdate - $sess->studentsearlyopentime) {
             $canmark = true;
             $reason = '';
         } else {


### PR DESCRIPTION
The first commit ensures that the 'Submit attendance' link does not appear before the period defined with studentsearlyopentime.

The second commit ensures that:
- if a status is not available once the session has started, it is only unset once the session has begun but stays available before if availablebeforesession is true.
- if a status is availablebeforesession, it's only available for the period set by studentsearlyopentime.